### PR TITLE
/api/users SSR対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "express": "^4.15.3",
     "express-jwt": "^5.3.0",
     "express-session": "^1.15.3",
+    "isomorphic-fetch": "^2.2.1",
     "jsonwebtoken": "^7.4.1",
     "lodash": "^4.17.4",
     "method-override": "^2.3.9",
@@ -54,6 +55,7 @@
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.5",
     "react-router-dom": "^4.1.1",
+    "react-router-server": "^4.2.1",
     "redux": "^3.7.0",
     "serve-favicon": "^2.4.3"
   },

--- a/src/app/Routes.jsx
+++ b/src/app/Routes.jsx
@@ -5,19 +5,80 @@ import {
   Link,
   Redirect,
 } from 'react-router-dom';
+import 'isomorphic-fetch';
 
-export default () => (
-  <div>
-    <ul>
-      <li><Link to="/">TOP</Link></li>
-      <li><Link to="/users">Users</Link></li>
-      <li><Link to="/users/594b9cb0a761f1ad5c890d65">User Detail</Link></li>
-    </ul>
+function Top() {
+  return <div>Top</div>;
+}
 
-    <Switch>
+class Users extends React.Component {
+  static fetchData({ urlHeader }) {
+    // Promiseで初期データを返せばいい気がするぞ
+    return new Promise((resolve, reject) => {
+      fetch(`${urlHeader}/api/users`)
+        .then(data => data.json())
+        .then(users => resolve({ users }))
+        .catch(error => reject(error));
+    });
+  }
 
-    </Switch>
-  </div>
-);
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+  }
 
-//
+  onClick(event) {
+    console.log(event);
+  }
+
+  render() {
+    return (
+      <section onClick={this.onClick} tabIndex="0" role="link">
+        <ul>
+        {(this.props.users || []).map(({ name }, i) => <li key={i.toString()}>{name}</li>)}
+        </ul>
+      </section>
+    );
+  }
+}
+
+function UserDetail({ match: { params: { id } } }) {
+  return <div>UserDetail: {id}</div>;
+}
+
+function HOC(Component, props) {
+  return (
+    <Component {...props} />
+  );
+}
+
+export const routes = [
+  { path: '/', component: Top },
+  { path: '/users', component: Users },
+  { path: '/users/:id', component: UserDetail },
+];
+
+export default function (props) {
+  // console.log(state);
+  return (
+    <div>
+      <ul>
+        <li><Link to="/">TOP</Link></li>
+        <li><Link to="/users">Users</Link></li>
+        <li><Link to="/users/aaa">User Detail:aaa</Link></li>
+        <li><Link to="/users/bbb">User Detail:bbb</Link></li>
+        <li><Link to="/lsdflkjsdflkjll">lsdflkjsdflkjll (Redirect to Top)</Link></li>
+      </ul>
+
+      <Switch>
+        {routes.map(({ path, component }) => (
+          // https://github.com/ReactTraining/react-router/issues/4105#issuecomment-294315922
+          <Route exact key={path} path={path} render={iDontKnowProps => HOC(component, { ...props, ...iDontKnowProps })} />
+        ))}
+        <Redirect from="*" to="/" />
+      </Switch>
+
+    </div>
+  );
+}
+// {routes.map(({ path, component }) => <Route exact key={path} path={path} component={component} {...props} />)}

--- a/src/app/app.jsx
+++ b/src/app/app.jsx
@@ -6,9 +6,8 @@ import { store, actions } from './Store';
 
 const initialState = JSON.parse(document.querySelector('#initial-data').dataset.json);
 
-
 ReactDOM.render((
   <BrowserRouter>
-    <Routes />
+    <Routes {...initialState} />
   </BrowserRouter>
 ), document.getElementById('app'));

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { renderToString } from 'react-dom/server';
-import { StaticRouter } from 'react-router-dom';
-import Routes from './app/Routes';
+// import { renderToString } from 'react-dom/server';
+import { renderToString } from 'react-router-server';
+import { StaticRouter, matchPath } from 'react-router-dom';
+import Routes, { routes } from './app/Routes';
 
 import errors from './components/errors';
 import user from './api/user';
@@ -16,15 +17,40 @@ export default (app) => {
     .all(errors[404]);
 
   app.route('/*')
-    .get((req, res) => {
+    .get(async (req, res) => {
+      const match = routes.reduce((acc, route) => matchPath(req.url, route.path, { exact: true }) || acc, null);
+
+      if (!match) {
+        // no matching route
+        res.status(404);
+        return;
+      }
+      const matchRoute = routes.filter(({ path }) => path === match.path)[0];
+      if (matchRoute.component.fetchData) {
+        // 初期化データ取得処理あり
+        const appState = await matchRoute.component.fetchData({ urlHeader: 'http://localhost:9077' });
+        console.log(appState);
+
+        const context = {};
+        const component = await renderToString(
+          <StaticRouter location={req.url} context={context}>
+            <Routes {...appState} />
+          </StaticRouter>,
+        );
+
+        return res.render('_app', { component: component.html, appState: JSON.stringify(appState) });
+      }
+
+      // 初期化データ取得処理なし
       const context = {};
-      const component = renderToString(
+      const component = await renderToString(
         <StaticRouter location={req.url} context={context}>
           <Routes />
-        </StaticRouter>);
+        </StaticRouter>,
+      );
 
       return res.render('_app', {
-        component,
+        component: component.html,
         appState: JSON.stringify({ data: 'testtesttest', a: 22 }),
       });
     })

--- a/src/views/_app.ejs
+++ b/src/views/_app.ejs
@@ -14,7 +14,7 @@ const conf = {
     // 環境変数のUniversal
     window.process = {
       env: {
-        NODE_ENV: '<%-process.env.NODE_ENV%>'
+        NODE_ENV: '<%- process.env.NODE_ENV %>'
       }
     };
 

--- a/tools/webpack/server.js
+++ b/tools/webpack/server.js
@@ -13,7 +13,10 @@ const externals = (() => {
 })();
 
 const base = {
-  entry: path.join(__dirname, '../../src/server'),
+  entry: [
+    'babel-polyfill',
+    path.join(__dirname, '..', '..', 'src', 'server'),
+  ],
   output: {
     filename: 'server/server.build.js',
     sourceMapFilename: 'server/server.build.map'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4563,7 +4563,7 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:
@@ -6763,6 +6763,10 @@ react-router-dom@^4.1.1:
     loose-envify "^1.3.1"
     prop-types "^15.5.4"
     react-router "^4.1.1"
+
+react-router-server@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/react-router-server/-/react-router-server-4.2.1.tgz#4ffd68bfcc983d22f8d185b4d306f1cc28ac8bc8"
 
 react-router@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
表題の通り。
適当にブレイク打って確認すると、サーバ側でfetchして取ってきてるのわかると思います。
まだusersのみの対応です。

が。ががが。
react-router-serverには `fetchState` という、
これで初期化してねと言わんばかりのネタが追加されてるので
これでやったほうがよかったかと思うのですが、なんとなくredux専用っぽくも見えるので一旦見送りました。
https://www.npmjs.com/package/react-router-server#fetch-state-usage

Decoratorなのでま〜たbabelプラグイン突っ込まないとしないとダメです。
https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy